### PR TITLE
最終課題・商品出品時のエラー未表示を修正

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,10 +15,10 @@ class Item < ApplicationRecord
     validates :name,                   length: { maximum: 40 }
     validates :info,                   length: { maximum: 1000 }
   end
-  validates :category_id,            numericality: { other_than: 0, message: "can't be blank" }
-  validates :sales_status_id,        numericality: { other_than: 0, message: "can't be blank" }
-  validates :shipping_fee_status_id, numericality: { other_than: 0, message: "can't be blank" }
-  validates :prefecture_id,          numericality: { other_than: 0, message: "can't be blank" }
-  validates :scheduled_delivery_id,  numericality: { other_than: 0, message: "can't be blank" }
+  validates :category_id,            numericality: { other_than: 1, message: "can't be blank" }
+  validates :sales_status_id,        numericality: { other_than: 1, message: "can't be blank" }
+  validates :shipping_fee_status_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :prefecture_id,          numericality: { other_than: 1, message: "can't be blank" }
+  validates :scheduled_delivery_id,  numericality: { other_than: 1, message: "can't be blank" }
   validates :price,                  numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
 end


### PR DESCRIPTION
デプロイで確認する際に、カテゴリーの項目のエラー表示ないのに気付いた。

今回はそのエラーを修正いたしました。

キャプチャー画像です。
https://gyazo.com/e9a98cc7d6be5529569a2a9365210779

ご確認の程、宜しくお願い致します。
