### PR TITLE
最終課題・商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,10 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
+  before_action :item_data, only: [:show, :edit]
 
   def index
     @item = Item.all.order('created_at DESC')
@@ -19,11 +20,9 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   private
@@ -32,5 +31,9 @@ class ItemsController < ApplicationController
     params.require(:item).permit(
       :image, :name, :info, :category_id, :sales_status_id, :shipping_fee_status_id, :prefecture_id, :scheduled_delivery_id, :price, :sales_item
     ).merge(user_id: current_user.id)
+  end
+
+  def item_data
+    @item = Item.find(params[:id])
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,6 +11,7 @@ class Item < ApplicationRecord
   belongs_to_active_hash :scheduled_delivery
 
   with_options presence: true do
+    validates :image
     validates :name,                   length: { maximum: 40 }
     validates :info,                   length: { maximum: 1000 }
   end
@@ -24,4 +25,33 @@ class Item < ApplicationRecord
   end
 
   validates :price,                  numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
+
+  def self.save_from_yml!(yml_path)
+    yml = yml.load(yml_path)
+    item = self.new
+    item.image = yml['image']
+    item.name = yml['name']
+    item.info = yml['info']
+    item.category_id = yml['category_id']
+    item.sales_status_id = yml['sales_status_id']
+    item.shipping_fee_status_id = yml['shipping_fee_status_id']
+    item.prefecture_id = yml['prefecture_id']
+    item.scheduled_delivery_id = yml['scheduled_delivery_id']
+    item.price = yml['price']
+    item.save_from_yml!
+  end
+
+  def self.edit_item!(image, name, info, category_id, sales_status_id, shipping_fee_status_id,prefecture_id, scheduled_delivery_id, price)
+    item = self.new
+    item.image = self.find_by!(data: image)
+    item.name = self.find_by!(data: name)
+    item.info = self.find_by!(data: info)
+    item.category_id = self.find_by!(data: category_id)
+    item.sales_status_id = self.find_by!(data: sales_status_id)
+    item.shipping_fee_status_id = self.find_by!(data: shipping_fee_status_id)
+    item.prefecture_id = self.find_by!(data: prefecture_id)
+    item.scheduled_delivery_id = self.find_by!(data: scheduled_delivery_id)
+    item.price = self.find_by!(data: price)
+    item.save!
+  end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,8 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, local: true do |f| %>
+
+  <%= form_with model: @item, local: true do |f| %>
 
     <%= render 'shared/error_messages', model: @item %>
 
@@ -50,7 +51,7 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category_id, Category.all, :id, :name, , {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
@@ -147,9 +148,9 @@ app/assets/stylesheets/items/new.css %>
 
   <footer class="items-sell-footer">
     <ul class="menu">
-      <li><%= link_to 'プライバシーポリシー', edit_new_path %></li>
-      <li><%= link_to 'フリマ利用規約', edit_new_path %></li>
-      <li><%= link_to '特定商取引に関する表記', edit_new_path %></li>
+      <li><%= link_to 'プライバシーポリシー', edit_item_path(@item) %></li>
+      <li><%= link_to 'フリマ利用規約', edit_item_path(@item) %></li>
+      <li><%= link_to '特定商取引に関する表記', edit_item_path(@item) %></li>
     </ul>
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
     <p class="inc">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <% if user_signed_in? && (current_user == @item.user ) %>
-      <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
+      <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% end %>


### PR DESCRIPTION
実装したこと
・商品情報（商品画像・商品名・商品の状態など）を変更できること
・出品者だけが編集ページに遷移できること
・商品出品時とほぼ同じUIで編集機能が実装できること　
・商品名やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で表示されること
・エラーハンドリングができていること

出品者だけが編集ページに遷移できることを確認できる画像と、
商品名やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で表示されることが確認できる画像です
　https://gyazo.com/532201d2add7193cd3a001a784a04835
　https://gyazo.com/d4fb4361262f7922fae10da457872263

商品情報（商品画像・商品名・商品の状態など）を変更できることが確認できる画像です。
　https://gyazo.com/6de55c405248800f22d913ddc865472d

　また、商品出品時とほぼ同じUIで編集機能が実装できること、は元から同じだった為、特にこれのために記述を変えたことはしていません。

ご確認の程、宜しくお願い致します。